### PR TITLE
Molecule test

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,14 @@
+---
+on:
+  - push
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          path: "${{ github.repository }}"
+      - name: molecule
+        uses: robertdebock/molecule-action@2.6.8

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- added molecule tests
 ### Changed
+- switch to `copy` for correct idempotency
+- clean up creation of `.ssh` directory
 ### Removed
 
 ## [v1.0.2] - 2020-12-17

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -1,0 +1,15 @@
+*******
+Delegated driver installation guide
+*******
+
+Requirements
+============
+
+This driver is delegated to the developer.  Up to the developer to implement
+requirements.
+
+Install
+=======
+
+This driver is delegated to the developer.  Up to the developer to implement
+requirements.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,21 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "install deps"
+      apt:
+        name:
+          - git
+          - python-setuptools
+          - python3-six
+          - python3
+          - python3-pip
+          - python3-dev
+          - python3-venv
+          - python3-setuptools
+          - virtualenv
+        state: present
+        update_cache: yes
+    - name: "Include certagent_role"
+      include_role:
+        name: "certagent_role"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,20 +2,19 @@
 - name: Converge
   hosts: all
   tasks:
-    - name: "install deps"
+    # these aren't strictly deps for certagent
+    # ansible requires certain packages to be installed
+    # on the host for it to be able to run `git` and `pip`
+    # tasks
+    - name: "install ansible deps"
       apt:
         name:
           - git
           - python-setuptools
-          - python3-six
-          - python3
-          - python3-pip
-          - python3-dev
-          - python3-venv
-          - python3-setuptools
           - virtualenv
         state: present
         update_cache: yes
+
     - name: "Include certagent_role"
       include_role:
         name: "certagent_role"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,16 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: certagent-instance
+    image: geerlingguy/docker-ubuntu1604-ansible
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,10 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,8 +49,10 @@
   tags: ['cert_agent', 'cert_agent:virtualenv']
 
 - name: Wire project directory to the virtualenv
-  become_user: "{{ cert_agent_app_user }}"
-  shell: echo "{{cert_agent_git_repo_dir}}" > {{cert_agent_venv_dir}}/.project
+  copy:
+    content: "{{cert_agent_git_repo_dir}}"
+    dest: "{{cert_agent_venv_dir}}/.project"
+    owner: "{{ cert_agent_app_user }}"
   tags: ['cert_agent', 'cert_agent:virtualenv']
 
 - name: Check Django installation
@@ -107,6 +109,13 @@
     - reload systemd configuration
     - restart cert_agent
   tags: ['cert_agent', 'cert_agent:configuration']
+
+- name: Create ~/.ssh directory
+  file:
+    path: "/home/{{ cert_agent_app_user }}/.ssh"
+    state: directory
+    owner: "{{ cert_agent_app_user }}"
+  tags: ['cert_agent', 'cert_agent:install']
 
 - name: Copy cert_agent ssh private key
   become_user: "{{ cert_agent_app_user }}"


### PR DESCRIPTION
Add a github action to automatically test the role using [molecule](https://molecule.readthedocs.io/en/latest/).

I'm putting together a blog post in the near future to explain all of this but the quick version at least is that molecule is a nice framework for building one or more docker images, installing your role into it, ensuring that that can be done cleanly, running an idempotence check, and will auto-discover and execute any actual tests that you define (we haven't added any yet, but now we can). This is an early step, but should be helpful for letting us write more robust ansible roles.

In the process of setting it up, I found two issues with the role that I had to fix to get the default tests passing:

* the `/home/certagent/.ssh` directory was not being created before it tried to write a key there.
* writing to `.project` in the venv with a shell command always sets the `changed` state to True, so it was failing the idempotency check. I replaced that with a simple `copy` so ansible is able to tell when it's run without changing anything.